### PR TITLE
Fixed regression introduced while cleaning up reflection warnings

### DIFF
--- a/src/librarian_clojure/repl.clj
+++ b/src/librarian_clojure/repl.clj
@@ -18,7 +18,7 @@
   (tools/cljs-repl))
   ;;
   (let [port (Integer/parseInt (get (System/getenv) "PORT" "8080"))]
-    (alter-var-root *server* (fn [_] (core/start-server port)))
+    (alter-var-root (var *server*) (fn [_] (core/start-server port)))
     (browse/browse-url (str "http://localhost:" port))))
 
 (defn stop


### PR DESCRIPTION
Here's a promised fix in repl namespace. Still, the repl itself does not (and didn't) actually work. There's a reference to non-existent "tools/cljs-repl". From quick search, I suppose that the original author intended  to use https://github.com/cemerick/piggieback - however, this would probably require some additional steps (starting with adding project depedency).
