### PR TITLE
Core future facts

### DIFF
--- a/test/librarian_clojure/test/core.clj
+++ b/test/librarian_clojure/test/core.clj
@@ -3,40 +3,42 @@
         midje.sweet)
   (:require [librarian-clojure.books :as books]
             [clojure.data.json :as json]
-            [ring.mock.request :as ring]))
+            [ring.mock.request :as ring]
+            [cemerick.friend :as friend]))
 
 (def book {:author "Robert C. Martin" :title "Clean Code"})
 
-(future-fact "get /books -> list all books"
+(fact "get /books -> list all books"
   (let [req (ring/request :get "/books")
-        res (app req)
-        _ (println "+++ response" res)]
+        res (app req)]
     (:status res) => 200
-    (:body res) => (json/json-str "Get Books")
-    (provided
-      (books/get-books) => "Get Books")))
+    (:body res) => (json/json-str "Get Books"))
+  (against-background
+    (books/get-books) => "Get Books"))
 
-(future-fact "post /books/:id -> update existing"
-      (let [req (ring/request :post "/books/15" book)
-            response (app req)]
-        (:status response) => 200
-        (:body response) => (json/json-str "Update as expected"))
-      (let [req (ring/request :post "/books/" book)
-            response (app req)]
-        (:status response) => 302
-        (:headers response) => {"Location" "/"})
-      (provided
-        (books/update-book "15" "Robert C. Martin" "Clean Code") => "Update as expected"))
+(fact "post /books/:id -> update existing"
+  (let [req (ring/request :post "/books/15" book)
+        res (app req)]
+    (:status res) => 200
+    (:body res) => (json/json-str "Update as expected"))
+  (let [req (ring/request :post "/books/" book)
+        res (app req)]
+    (:status res) => 302
+    (:headers res) => {"Location" "/"})
+  (against-background
+    (friend/authorized? anything anything) => true
+    (books/update-book "15" "Robert C. Martin" "Clean Code") => "Update as expected"))
 
-(future-fact "put /books -> insert new"
-      (against-background 
-        (books/add-book "Robert C. Martin" "Clean Code") => (str "Insert as expected"))
-      (let [req (ring/request :put "/books" book)
-            response (app req)]
-        (:status response) => 200
-        (:body response) => (json/json-str "Insert as expected")))
+(fact "put /books -> insert new"
+  (let [req (ring/request :put "/books" book)
+        response (app req)]
+    (:status response) => 200
+    (:body response) => (json/json-str "Insert as expected"))
+  (against-background 
+    (friend/authorized? anything anything) => true
+    (books/add-book "Robert C. Martin" "Clean Code") => (str "Insert as expected")))
 
-(future-fact "delete /books/:id -> delete"
+(fact "delete /books/:id -> delete"
   (let [req (ring/request :delete "/books/15")
         response (app req)]
     (:status response) => 200
@@ -44,4 +46,7 @@
   (let [req (ring/request :delete "/books")
         response (app req)]
     (:status response) => 302
-    (:headers response) => {"Location" "/"}))
+    (:headers response) => {"Location" "/"})
+  (against-background 
+    (friend/authorized? anything anything) => true
+    (books/delete-book "15") => (str "Delete as expected")))

--- a/test/librarian_clojure/test/security.clj
+++ b/test/librarian_clojure/test/security.clj
@@ -4,8 +4,6 @@
   (:require [librarian-clojure.db :as db]
             [ring.mock.request :as ring]))
 
-(def identity-request (ring/request :get "/books"))
-
 (fact "get-user-by-login username contract"
   (get-user-by-login "admin") => (contains {:username "admin"})
   (provided (db/db-get-user "admin") => {:login "admin"}))

--- a/test/librarian_clojure/test/security.clj
+++ b/test/librarian_clojure/test/security.clj
@@ -1,0 +1,11 @@
+(ns librarian-clojure.test.security
+  (:use librarian-clojure.security
+        midje.sweet)
+  (:require [librarian-clojure.db :as db]
+            [ring.mock.request :as ring]))
+
+(def identity-request (ring/request :get "/books"))
+
+(fact "get-user-by-login username contract"
+  (get-user-by-login "admin") => (contains {:username "admin"})
+  (provided (db/db-get-user "admin") => {:login "admin"}))


### PR DESCRIPTION
I've fixed the facts in core and added a simple (and actually the only relevant in my opinion) test for function retrieving user details for use by cemerick/friend. I've tried adding some tests for signup-handler-workflow but came to conclusion that it's not worth the sweat (just one if branch actually) - while trying to accomplish it (and also on occasion of fixing earlier facts) I've tripped up on nasty "provided" behavior which - when put in the wrong context - caused a complete repl lockup. When such malformed fact was run from emacs buffer, I've often ended up forcefully killing all repl related clojure processes. Anyway that's all for tonight on my side - not much actually, but I've wasted considerable amount of time trying to sort out that "provided" issue...
